### PR TITLE
css template tag

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    // Add options here
+    babel: {
+      plugins: ['glamor/babel']
+    }
   });
 
   /*

--- a/tests/integration/css-test.js
+++ b/tests/integration/css-test.js
@@ -1,0 +1,60 @@
+import Ember from 'ember';
+
+import hbs from 'htmlbars-inline-precompile';
+
+import { css } from 'glamor';
+import { moduleForComponent, test } from 'ember-qunit';
+
+
+const { Component } = Ember;
+
+
+moduleForComponent('show-colors', 'css', {
+  integration: true
+});
+
+
+test('render styles with css function', function(assert) {
+  assert.expect(1);
+
+  const style = css({
+    backgroundColor: 'red'
+  });
+
+  this.register('component:test-component', Component.extend({
+    style,
+    layout: hbs`
+
+    <span class={{style}}>This is red</span>
+
+    `
+  }));
+
+  this.render(hbs`{{test-component}}`);
+
+  assert.equal(this.$('span').css('backgroundColor'), 'rgb(255, 0, 0)');
+});
+
+
+test('render styles with css template tag', function(assert) {
+  assert.expect(1);
+
+  const style = css`
+
+  backgroundColor: red;
+
+  `;
+
+  this.register('component:test-component', Component.extend({
+    style,
+    layout: hbs`
+
+    <span class={{style}}>This is red</span>
+
+    `
+  }));
+
+  this.render(hbs`{{test-component}}`);
+
+  assert.equal(this.$('span').css('backgroundColor'), 'rgb(255, 0, 0)');
+});


### PR DESCRIPTION
**NOT WORKING**

This will test/document glamor's [css template tag](https://github.com/threepointone/glamor/blob/master/docs/css.md) feature:

```js
import { css } from 'glamor';

const style = css`

background-color: red;
max-width: 200px;

`;

export default Component.extend({ style });
```

This uses a babel plugin that likely only works with babel 6, which is not supported by ember-cli yet.

Follow along here: https://github.com/ember-cli/ember-cli/issues/5015